### PR TITLE
Add missing commas in sample code

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,10 +11,10 @@ Configure logging to Seq
 
    seqlog.log_to_seq(
       server_url="http://my-seq-server:5431/",
-      api_key="My API Key"
+      api_key="My API Key",
       level=logging.INFO,
       batch_size=10,
-      auto_flush_timeout=10000  # milliseconds
+      auto_flush_timeout=10000,  # milliseconds
       override_root_logger=True
    )
 


### PR DESCRIPTION
Hi! Looks like the sample code is missing a couple of argument separator commas.

Via: http://docs.getseq.net/v4/discuss/5a1ac17b40241b0012c2f160
