### PR TITLE
Add support for custom JSON encoders

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,8 @@ Configure logging programmatically
       level=logging.INFO,
       batch_size=10,
       auto_flush_timeout=10000,  # milliseconds
-      override_root_logger=True
+      override_root_logger=True,
+      json_encoder_class=json.encoder.JSONEncoder  # Optional; only specify this if you want to use a custom JSON encoder
    )
 
 For the best experience, use ``{x}``-style named format arguments (passing those format arguments as keyword arguments to the log functions ``info``, ``warning``, ``error``, ``critical``, etc).
@@ -81,6 +82,9 @@ First, create your configuration file (e.g. ``/foo/bar/my_config.yml``):
         # Seq-specific settings (add any others you need, they're just kwargs for SeqLogHandler's constructor).
         server_url: 'http://localhost:5341'
         api_key: 'your_api_key_if_you_have_one'
+
+        # Use a custom JSON encoder, if you need to.
+        json_encoder_class: json.encoder.JSONEncoder
 
     formatters:
       seq:

--- a/seqlog/__init__.py
+++ b/seqlog/__init__.py
@@ -61,6 +61,7 @@ def configure_from_dict(config, override_root_logger=True, use_structured_logger
 def log_to_seq(server_url, api_key=None, level=logging.WARNING,
                batch_size=10, auto_flush_timeout=None,
                additional_handlers=None, override_root_logger=False,
+               json_encoder_class=None,
                **kwargs):
     """
     Configure the logging system to send log entries to Seq.
@@ -76,6 +77,7 @@ def log_to_seq(server_url, api_key=None, level=logging.WARNING,
     :param override_root_logger: Override the root logger, too?
                                  Note - this might cause problems if third-party components try to be clever
                                  when using the logging.XXX functions.
+    :json_encoder_class: The custom JSONEncoder class (if any) to use. It not specified, the default JSONEncoder will be used.
     :return: The `SeqLogHandler` that sends events to Seq. Can be used to forcibly flush records to Seq.
     :rtype: SeqLogHandler
     """
@@ -86,7 +88,7 @@ def log_to_seq(server_url, api_key=None, level=logging.WARNING,
         _override_root_logger()
 
     log_handlers = [
-        SeqLogHandler(server_url, api_key, batch_size, auto_flush_timeout)
+        SeqLogHandler(server_url, api_key, batch_size, auto_flush_timeout, json_encoder_class)
     ]
 
     if additional_handlers:


### PR DESCRIPTION
Relates to tintoy/seqlog#7 and tintoy/seqlog#13.

`SeqLogHander` constructor now takes an additional (optional) keyword argument called `json_encoder_class` which is a class that derives from `json.encoder.JSONEncoder` (see [here](https://docs.python.org/3/library/json.html) under "Extending JSONEncoder" for details).

CC: @snailkn @blint587