### PR TITLE
Enable the user to specify a callable as a global log property

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Add an option to specify a callable in global properties
+
 0.3.17 (2020-02-14)
 -------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,8 +177,14 @@ with no arguments right before logging:
 
     import seqlog
 
+    def get_trace_id():
+        if tracer.active_span is not None:
+            return hex(tracer.active_span.context.trace_id)
+        else:
+            return None
+
     seqlog.set_global_log_properties(
-        trace_id=lambda: tracer.active_span.context.trace_id,
+        trace_id=get_trace_id,
     )
 
 If the callable returns None, it won't be added.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -180,3 +180,5 @@ with no arguments right before logging:
     seqlog.set_global_log_properties(
         trace_id=lambda: tracer.active_span.context.trace_id,
     )
+
+If the callable returns None, it won't be added.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -169,3 +169,14 @@ To configure global log properties, call ``set_global_log_properties``, passing 
     )
 
 Note that you can also clear the global log properties (so no properties are added) by calling ``clear_global_log_properties``, and reset the global log properties to their defaults by calling ``reset_global_log_properties``.
+
+Note that is you specify a callable as part of global log properties, it will be called
+with no arguments right before logging:
+
+.. code-block:: python
+
+    import seqlog
+
+    seqlog.set_global_log_properties(
+        trace_id=lambda: tracer.active_span.context.trace_id,
+    )

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -65,8 +65,7 @@ def set_global_log_properties(**properties):
     """
 
     global _global_log_props, _global_log_props_is_raw_dict
-    if any(callable(v) for v in properties.values()):
-        _global_log_props_is_raw_dict = False
+    _global_log_props_is_raw_dict = not any(callable(v) for v in properties.values())
     _global_log_props = {key: value for (key, value) in properties.items()}
 
 

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import base64
+import copy
 import json
 import importlib
 import inspect
@@ -40,7 +41,7 @@ def get_global_log_properties(logger_name=None):
     :rtype: dict
     """
     if _global_log_props_is_raw_dict:
-        global_log_properties = {key: value for (key, value) in _global_log_props.items()}
+        global_log_properties = copy.copy(_global_log_props)
     else:
         global_log_properties = {}
         for k, v in _global_log_props.items():
@@ -66,7 +67,7 @@ def set_global_log_properties(**properties):
 
     global _global_log_props, _global_log_props_is_raw_dict
     _global_log_props_is_raw_dict = not any(callable(v) for v in properties.values())
-    _global_log_props = {key: value for (key, value) in properties.items()}
+    _global_log_props = copy.copy(properties)
 
 
 def reset_global_log_properties():

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -26,6 +26,8 @@ _default_global_log_props = {
 
 # Global properties attached to all log entries.
 _global_log_props = _default_global_log_props
+# Whether the _global_log_props DOES NOT contain any callables
+_global_log_props_is_raw_dict = True
 
 
 def get_global_log_properties(logger_name=None):
@@ -37,8 +39,14 @@ def get_global_log_properties(logger_name=None):
     :return: A copy of the global log properties.
     :rtype: dict
     """
-
-    global_log_properties = {key: value for (key, value) in _global_log_props.items()}
+    if _global_log_props_is_raw_dict:
+        global_log_properties = {key: value for (key, value) in _global_log_props.items()}
+    else:
+        global_log_properties = {}
+        for k, v in _global_log_props.items():
+            if callable(v):
+                v = v()
+            global_log_properties[k] = v
 
     if logger_name:
         global_log_properties["LoggerName"] = logger_name
@@ -54,8 +62,9 @@ def set_global_log_properties(**properties):
     :type properties: dict
     """
 
-    global _global_log_props
-
+    global _global_log_props, _global_log_props_is_raw_dict
+    if any(callable(v) for v in properties.values()):
+        _global_log_props_is_raw_dict = False
     _global_log_props = {key: value for (key, value) in properties.items()}
 
 
@@ -64,8 +73,8 @@ def reset_global_log_properties():
     Initialize global log properties to their default values.
     """
 
-    global _global_log_props
-
+    global _global_log_props, _global_log_props_is_raw_dict
+    _global_log_props_is_raw_dict = True
     _global_log_props = _default_global_log_props
 
 
@@ -74,8 +83,8 @@ def clear_global_log_properties():
     Remove all global properties.
     """
 
-    global _global_log_props
-
+    global _global_log_props, _global_log_props_is_raw_dict
+    _global_log_props_is_raw_dict = True
     _global_log_props = {}
 
 
@@ -447,7 +456,7 @@ class SeqLogHandler(logging.Handler):
                 "Timestamp": _get_local_timestamp(record),
                 "Level": logging.getLevelName(record.levelno),
                 "MessageTemplate": record.getMessage(),
-                "Properties": _global_log_props
+                "Properties": get_global_log_properties()
             }
 
         if record.exc_text:

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -46,6 +46,8 @@ def get_global_log_properties(logger_name=None):
         for k, v in _global_log_props.items():
             if callable(v):
                 v = v()
+                if v is None:
+                    continue
             global_log_properties[k] = v
 
     if logger_name:


### PR DESCRIPTION
If a callable is given, it will be evaluated at _log time. This way you can for example add current trace IDs (if you're using tracing).
If the callable returns None, it won't be included at that time.