### PR TITLE
Handle correctly invalid log entries

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Piotr Maślanka <pmaslanka@smok.co>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Fixed logging messages containing braces
+
 0.3.18 (2020-09-13)
 -------------------
 

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -132,7 +132,11 @@ class StructuredLogRecord(logging.LogRecord):
         if self.args:
             return self.msg % self.args
         elif self.log_props:
-            return self.msg.format(**self.log_props)
+            try:
+                return self.msg.format(**self.log_props)
+            except (KeyError, IndexError):
+                # IndexError because sometimes the wrong log messages go like {existing_prop[0]}
+                return self.msg   # handle the situation where we have braces in the logging value
         else:
             return self.msg
 

--- a/tests/test_structured_log_record.py
+++ b/tests/test_structured_log_record.py
@@ -45,6 +45,10 @@ class TestStructuredLogRecord(object):
 
         expect.log_template(record, "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}")
 
+    def test_log_invalid_keys(self):
+        msg = self.create_test_log_record(logging.INFO, '{invalid} {test}').getMessage()
+        assert msg == '{invalid} {test}'
+
     def test_named_arguments_level(self):
         record = self.create_test_log_record(
             logging.WARNING,


### PR DESCRIPTION
Seq log handler has an issue with braces. It will try to parse braces as a Python expression, whereas that might not have been the intent all along (eg. when logging gRPC issues).

I fixed that.