### PR TITLE
Add a callable to call each time log submission fails

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.3.20 (TBA)
+------------
+
+* Added a callable to be called each time log submission fails
+
 0.3.19 (2020-10-15)
 -------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -188,3 +188,18 @@ with no arguments right before logging:
     )
 
 If the callable returns None, it won't be added.
+
+Callback on log submission failure
+----------------------------------
+
+If you wish to set a callable to be invoked each time log submission fails, 
+use the following function:
+
+.. code-block:: python
+
+    from seqlog import set_callback_on_failure
+    
+    def handle_a_failure(e):    # type: (Exception) -> None
+        print('Failure occurred during log submission: %s' % (e, ))
+        
+   set_callback_on_failure(handle_a_failure)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -206,3 +206,7 @@ use the following function:
 
 The callable that you provide will accept a single positional argument, 
 which is the requests exception instance that was the reason for the fail.
+
+.. note:: This callable will be called only for I/O errors, errors stemming
+          from seqlog not being able to convert your records into JSON won't
+          show up here!

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -199,7 +199,10 @@ use the following function:
 
     from seqlog import set_callback_on_failure
     
-    def handle_a_failure(e):    # type: (Exception) -> None
+    def handle_a_failure(e):    # type: (requests.RequestException) -> None
         print('Failure occurred during log submission: %s' % (e, ))
         
    set_callback_on_failure(handle_a_failure)
+
+The callable that you provide will accept a single positional argument, 
+which is the requests exception instance that was the reason for the fail.

--- a/seqlog/__init__.py
+++ b/seqlog/__init__.py
@@ -10,6 +10,7 @@ from seqlog.structured_logging import get_global_log_properties as _get_global_l
 from seqlog.structured_logging import set_global_log_properties as _set_global_log_properties
 from seqlog.structured_logging import clear_global_log_properties as _clear_global_log_properties
 from seqlog.structured_logging import reset_global_log_properties as _reset_global_log_properties
+from seqlog.structured_logging import set_callback_on_failure
 
 __author__ = 'Adam Friedman'
 __email__ = 'tintoy@tintoy.io'

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -34,6 +34,7 @@ _callback_on_failure = None     # type: typing.Callable[[Exception], None]
 
 def set_callback_on_failure(callback):  # type: (typing.Callable[[Exception], None]) -> None
     global _callback_on_failure
+    assert callable(callback), 'Given callback is not callable'
     _callback_on_failure = callback
 
 

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -371,7 +371,7 @@ class SeqLogHandler(logging.Handler):
         finally:
             super().close()
 
-    def publish_log_batch(self, batch):
+    def publish_log_batch(self, batch):     # type: (typing.Iterable[logging.LogRecord]) -> None
         """
         Publish a batch of log records.
 

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -371,7 +371,7 @@ class SeqLogHandler(logging.Handler):
         finally:
             super().close()
 
-    def publish_log_batch(self, batch):     # type: (typing.Iterable[logging.LogRecord]) -> None
+    def publish_log_batch(self, batch):     # type: (typing.Iterable[StructuredLogRecord]) -> None
         """
         Publish a batch of log records.
 

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -29,6 +29,12 @@ _default_global_log_props = {
 _global_log_props = _default_global_log_props
 # Whether the _global_log_props DOES NOT contain any callables
 _global_log_props_is_raw_dict = True
+_callback_on_failure = None     # type: typing.Callable[[Exception], None]
+
+
+def set_callback_on_failure(callback):  # type: (typing.Callable[[Exception], None]) -> None
+    global _callback_on_failure
+    _callback_on_failure = callback
 
 
 def get_global_log_properties(logger_name=None):
@@ -402,6 +408,9 @@ class SeqLogHandler(logging.Handler):
         except requests.RequestException as requestFailed:
             # Only notify for the first record in the batch, or we'll be generating too much noise.
             self.handleError(batch[0])
+
+            if _callback_on_failure is not None:
+                _callback_on_failure(requestFailed)
 
             # Attempt to log error response
             if not requestFailed.response:

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -5,6 +5,7 @@ import copy
 import json
 import importlib
 import inspect
+import typing as tp
 import logging
 import os
 import socket
@@ -29,10 +30,10 @@ _default_global_log_props = {
 _global_log_props = _default_global_log_props
 # Whether the _global_log_props DOES NOT contain any callables
 _global_log_props_is_raw_dict = True
-_callback_on_failure = None     # type: typing.Callable[[Exception], None]
+_callback_on_failure = None     # type: tp.Callable[[Exception], None]
 
 
-def set_callback_on_failure(callback):  # type: (typing.Callable[[Exception], None]) -> None
+def set_callback_on_failure(callback):  # type: (tp.Callable[[Exception], None]) -> None
     global _callback_on_failure
     assert callable(callback), 'Given callback is not callable'
     _callback_on_failure = callback
@@ -371,7 +372,7 @@ class SeqLogHandler(logging.Handler):
         finally:
             super().close()
 
-    def publish_log_batch(self, batch):     # type: (typing.Iterable[StructuredLogRecord]) -> None
+    def publish_log_batch(self, batch):     # type: (tp.Iterable[StructuredLogRecord]) -> None
         """
         Publish a batch of log records.
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -7,15 +7,34 @@ test_seqlog
 
 Tests for `seqlog.consumer.QueueConsumer` module.
 """
-
+import logging
 from queue import Queue
 from threading import Event
 from time import sleep
 
+import seqlog
+
+from seqlog.structured_logging import StructuredLogRecord
+
+from seqlog import SeqLogHandler
 from seqlog.consumer import QueueConsumer
 
 
 class TestLogRecordConsumer(object):
+
+    def test_callable_failures(self):
+        lh = SeqLogHandler('localhost')
+        le = StructuredLogRecord('test', logging.INFO, '/dev/null', 1, 'Hello world!', (), None)
+        callable_called = False
+
+        def handle_failure(e):
+            nonlocal callable_called
+            callable_called = True
+
+        seqlog.set_callback_on_failure(handle_failure)
+
+        lh.publish_log_batch([le])
+        self.assertTrue(callable_called)
     #
     # Without flush timeout
     #

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -34,7 +34,7 @@ class TestLogRecordConsumer(object):
         seqlog.set_callback_on_failure(handle_failure)
 
         lh.publish_log_batch([le])
-        self.assertTrue(callable_called)
+        assert callable_called
     #
     # Without flush timeout
     #


### PR DESCRIPTION
So that you can detect via other mechanisms (eg. metrics) that you logging has just failed