### PR TITLE
warning if message was None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.3.21 (TBA)
+------------
+
+* added checking if None was passed as element of a message
+
 0.3.20 (2020-10-15)
 -------------------
 

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -10,6 +10,7 @@ import logging
 import os
 import socket
 import sys
+import warnings
 from datetime import datetime
 from dateutil.tz import tzlocal
 from queue import Queue
@@ -136,6 +137,9 @@ class StructuredLogRecord(logging.LogRecord):
         Get a formatted message representing the log record (with arguments replaced by values as appropriate).
         :return: The formatted message.
         """
+        if self.msg is None:
+            warnings.warn('You just passed a None as a message content!', UserWarning)
+            self.msg = ''
 
         if self.args:
             return self.msg % self.args

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ test_requirements = [
 
 setup(
     name='seqlog',
-    version='0.3.20',
+    version='0.3.21a1',
     description="SeqLog enables logging from Python to Seq.",
     long_description=readme + '\n\n' + history,
     author="Adam Friedman",

--- a/tests/test_structured_logger.py
+++ b/tests/test_structured_logger.py
@@ -19,6 +19,12 @@ from tests.stubs import StubStructuredLogHandler
 
 
 class TestStructuredLogger(object):
+
+    def test_passing_none(self):
+        logger, handler = create_logger()
+
+        logger.info(None)
+
     def test_ordinal_arguments_message(self):
         logger, handler = create_logger()
 


### PR DESCRIPTION
Having made a few mistakes by passing logger's None's instead of string messages, I've decided to add a warning that would protect us against that (and further failing the seqlog pipeline, and defend us from stupid AttributeErrors).