### PR TITLE
Fixed Travis

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ flake8>=2.6.0
 tox>=2.3.1
 coverage>=4.1
 Sphinx>=1.4.4
-cryptography>=1.4
+cryptography==1.6
 PyYAML>=3.11
 pytest>=2.9.2
 httmock>=1.2.5

--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -10,6 +10,7 @@ import logging
 import os
 import socket
 import sys
+import warnings
 from datetime import datetime
 from dateutil.tz import tzlocal
 from queue import Queue
@@ -136,6 +137,9 @@ class StructuredLogRecord(logging.LogRecord):
         Get a formatted message representing the log record (with arguments replaced by values as appropriate).
         :return: The formatted message.
         """
+        if self.msg is None:
+            warnings.warn('You just passed a None as a message content!', UserWarning)
+            self.msg = ''
 
         if self.args:
             return self.msg % self.args


### PR DESCRIPTION
Pip on travis attempted to install the latest cryptography, not one for which binary wheel are available.
[Here's an example of one happy Travis](https://travis-ci.com/github/smok-serwis/seqlog/builds). Check issue #34  for details.

I basically pegged test cryptography at 1.6, because that's the version that binary wheels are available for Python 3.6.

Besides, consider switching to Python 3.8 for testing. More wheels are available for it, and your tests currently don't pass on Python 3.8 due to some weird usage of `threading`.