### PR TITLE
Fix Travis builds

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ flake8>=2.6.0
 tox>=2.3.1
 coverage>=4.1
 Sphinx>=1.4.4
-cryptography>=1.4
+cryptography==1.6
 PyYAML>=3.11
 pytest>=2.9.2
 httmock>=1.2.5


### PR DESCRIPTION
I fixed Travis builds.

Turns out latest cryptography has no binary wheels for Python 3.6. Building cryptography locally is a complex assignment, so I thought pegging the development version at a crypto version which has those wheels would work great.

[Here you got a quite happy Travis](https://travis-ci.com/github/smok-serwis/seqlog/builds)

Please verify whether you can still submit packages to twine with this late crypto.