### PR TITLE
Updated ToxEnv to py310 (python 3.10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script: tox -e ${TOXENV}
 
 deploy:
   on:
-    condition: $TOXENV == py36
+    condition: $TOXENV == py310
     repo: tintoy/seqlog
     tags: true
 


### PR DESCRIPTION
running tox as `tox -e py310` worked locally for me. The last two builds for this branch failed, so hopefully this fixes it.