### PR TITLE
removed initial attempt at solving Issue #42 in structured_logging.py

### DIFF
--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -236,9 +236,6 @@ class StructuredLogger(logging.Logger):
         else:
             record = super().makeRecord(name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)
 
-        if sinfo and not record.exc_text:
-            setattr(record, 'exc_text', sinfo)
-
         return record
 
 


### PR DESCRIPTION
initial attempt at resolving Issue #42 ( `stack_info=True` not adding stack info to the logs going to the Seq server) was causing the stack to be printed twice into the console logs