### PR TITLE
Shorten SeqLogHandler._build_event_data() by cleaning up repeated code 

### DIFF
--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -236,9 +236,6 @@ class StructuredLogger(logging.Logger):
         else:
             record = super().makeRecord(name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)
 
-        if sinfo and not record.exc_text:
-            setattr(record, 'exc_text', sinfo)
-
         return record
 
 


### PR DESCRIPTION
Focused a bit more on generating the `event_data` dict instead of updating the `record` object, and moved the byte and json encoding, as well as the `event_data`  declaration to make the code more DRY.

The `if`'s more directly check that the `record` has the `log_props` or `args` properties to save from checking if its an instance of `StructuredLogRecord`, and adding items directly to the dict, removing the need for `log_props_shim`.

This could potentially also have performance benefits, but they'd likely be fairly minimal.