### PR TITLE
changes best_effort_json_encode to do not convert json to string

### DIFF
--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -326,7 +326,7 @@ def best_effort_json_encode(arg):
         return arg
 
     try:
-        return json.dumps(arg)
+        json.dumps(arg)
     except TypeError:
         try:
             return str(arg)
@@ -337,6 +337,8 @@ def best_effort_json_encode(arg):
                 return '<type %s>' % (type(arg), )
     except ReferenceError:
         return '<gone weak reference>'
+    else:
+        return arg
 
 
 class SeqLogHandler(logging.Handler):

--- a/tests/test_structured_logger.py
+++ b/tests/test_structured_logger.py
@@ -69,39 +69,45 @@ class TestStructuredLogger(object):
         logger, handler = create_logger()
 
         logger.info(
-            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}",
+            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}, Arg5 = {Argument5}",
             Argument1="Foo",
             Argument2="Bar",
             Argument3=b"Baz",
-            Argument4=7
+            Argument4=7,
+            Argument5={"Key1": 1, "Array": [{"InArrayNum1": 111, "InArrayStr1": "str1"}]}
         )
 
         record = handler.pop_record()
-        expect.log_message(record, "Arg1 = 'Foo', Arg2 = 'Bar', Arg3 = b'Baz', Arg4 = 7")
+        expect.log_message(record, "Arg1 = 'Foo', Arg2 = 'Bar', Arg3 = b'Baz', Arg4 = 7, "
+                                   "Arg5 = {'Key1': 1, 'Array': [{'InArrayNum1': 111, 'InArrayStr1': 'str1'}]}")
 
     def test_named_arguments_template(self):
         logger, handler = create_logger()
 
         logger.info(
-            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}",
+            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}, Arg5 = {Argument5}",
             Argument1="Foo",
             Argument2="Bar",
             Argument3=b"Baz",
-            Argument4=7
+            Argument4=7,
+            Argument5={"Key1": 1, "Array": [{"InArrayNum1": 111, "InArrayStr1": "str1"}]}
         )
 
         record = handler.pop_record()
-        expect.log_template(record, "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}")
+        expect.log_template(record,
+                            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, "
+                            "Arg4 = {Argument4}, Arg5 = {Argument5}")
 
     def test_named_arguments_level(self):
         logger, handler = create_logger(logging.WARNING)
 
         logger.warning(
-            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}",
+            "Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}, Arg5 = {Argument5}",
             Argument1="Foo",
             Argument2="Bar",
             Argument3=b"Baz",
-            Argument4=7
+            Argument4=7,
+            Argument5={"Key1": 1, "Array": [{"InArrayNum1": 111, "InArrayStr1": "str1"}]}
         )
 
         record = handler.pop_record()
@@ -110,16 +116,18 @@ class TestStructuredLogger(object):
     def test_named_arguments_args(self):
         logger, handler = create_logger()
 
-        logger.info(
-            "Arg1 = 'Arg1 = {Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, Arg4 = {Argument4}",
-            Argument1="Foo",
-            Argument2="Bar",
-            Argument3=b"Baz",
-            Argument4=7
-        )
+        logger.info("Arg1 = '{Argument1}', Arg2 = '{Argument2}', Arg3 = {Argument3}, "
+                    "Arg4 = {Argument4}, Arg5 = {Argument5}",
+                    Argument1="Foo",
+                    Argument2="Bar",
+                    Argument3=b"Baz",
+                    Argument4=7,
+                    Argument5={"Key1": 1, "Array": [{"InArrayNum1": 111, "InArrayStr1": "str1"}]})
 
         record = handler.pop_record()
-        expect.log_named_args(record, Argument1="Foo", Argument2="Bar", Argument3=b"Baz", Argument4=7, LoggerName="test")
+        expect.log_named_args(record, Argument1="Foo", Argument2="Bar", Argument3=b"Baz", Argument4=7,
+                              Argument5={"Key1": 1, "Array": [{"InArrayNum1": 111, "InArrayStr1": "str1"}]},
+                              LoggerName="test")
 
 
 def create_logger(level=logging.INFO):


### PR DESCRIPTION
When I was testing sending JSONs in arguments, I found out that everything is converted to the string. In consequence Seq, is interpreting JSON structures as a plain text. In this situation, we are loosing Seq features related to handling JSON data, like easy querying on JSON fields, folding, coloring etc. Therefore I changed best_effort_json_encode function. Now it is checking if a given parameter is a JSON object, and if it is, then it does not convert it to a string. If given argument is not a proper JSON structure (json.dumps throw TypeError), then it converts it to a string like it was before. 

Before:
![image](https://github.com/tintoy/seqlog/assets/22113075/fa7f9841-a436-4613-b1e5-3f9d6f985054)


After:
![image](https://github.com/tintoy/seqlog/assets/22113075/a5172310-009d-4947-baa3-22fa5c5d6c59)

I also added JSON objects to arguments in tests. 