### PR TITLE
Add support for CLEF plus some bugs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,11 +2,14 @@
 History
 =======
 
-Current
--------
+Current (0.4.0)  - (unreleased yet)
+-----------------------------------
 
 * You can enable and disable all of the feature flags at runtime
-
+* Added support for the `CLEF submission format <https://docs.datalust.co/docs/posting-raw-events>`_.
+* Fixed a bug wherein configure_from_file would not propagate feature flags
+* You can pass bare strings in the exc_info field (although this serves the same purpose as enabling STACK_INFO and using that variable)
+* A bugfix wherein `configure_from_file` would not relay it's arguments to `configure_from_dict` in the correct order
 
 0.3.31 (2024-04-27)
 -------------------

--- a/docs/feature_flags.rst
+++ b/docs/feature_flags.rst
@@ -1,0 +1,22 @@
+Feature flags
+-------------
+
+You can change certain behaviour of the software at runtime, even after you configure Seq. You'll have to use:
+
+.. autofunction:: seqlog.feature_flags.enable_feature
+
+.. autofunction:: seqlog.feature_flags.disable_feature
+
+.. autofunction:: seqlog.feature_flags.configure_feature
+
+.. autoclass:: seqlog.feature_flags.FeatureFlag
+    :members:
+
+An example to disable ignoring of submission errors for Seq failures would look like this:
+
+.. code-block:: python
+
+    from seqlog.feature_flags import disable_feature, FeatureFlag
+    
+    disable_feature(FeatureFlag.IGNORE_SEQ_SUBMISSION_ERRORS)
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Contents:
    usage
    usage-gunicorn
    Modules <api/modules>
+   feature_flags
    contributing
    authors
    history

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,6 +38,10 @@ The ordinal format arguments are stored in the log entry properties using the 0-
 
 Note that mixing named and ordinal arguments is not currently supported.
 
+The formal definition of the configure function is as follows:
+
+.. autofunction:: seqlog.log_to_seq
+
 Configure logging from a file
 -----------------------------
 
@@ -190,6 +194,14 @@ with no arguments right before logging:
 
 If the callable returns None, it won't be added.
 
+Note that some properties get different treatment if the CLEF mode is enabled.
+
+Note that there is a short list of these, these won't be attached to Properties. They will get removed from there and
+attached according to the `CLEF<https://clef-json.org/>`_ format:
+
+* ``span_id`` - this will get removed and be replaced with ``@sp``
+* ``trace_id`` - this will get removed and be replaced with ``@tr``
+
 Callback on log submission failure
 ----------------------------------
 
@@ -229,5 +241,7 @@ may come from a couple of places, in order:
     b. Else formatted :code:`exc_info` will be used
 
 4. If only :code:`exc_info` is given, and it's an Exception, then the stack trace will be attached.
+
+5. If :code:`exc_info` is a string, it will be attached. This is functionally the same thing as (2).
 
 So if you provide both :code:`exc_info` and :code:`stack_info` the code will behave in a way that's hard to put into words.

--- a/seqlog/__init__.py
+++ b/seqlog/__init__.py
@@ -48,16 +48,18 @@ def configure_from_file(file_name, override_root_logger=True, support_extra_prop
     with open(file_name) as config_file:
         config = yaml.load(config_file, Loader=yaml.SafeLoader)
 
-    configure_from_dict(config, override_root_logger, True, support_extra_properties, support_stack_info,
-                        ignore_seq_submission_errors, use_clef)
+    configure_from_dict(config, override_root_logger, True)
 
 
-def configure_from_dict(config, override_root_logger=True, use_structured_logger=True, support_extra_properties=False, support_stack_info=False, ignore_seq_submission_errors=False,
-                        use_clef=False):
+def configure_from_dict(config, override_root_logger=True, use_structured_logger=True, support_extra_properties=None,
+                        support_stack_info=None, ignore_seq_submission_errors=None,
+                        use_clef=None):
     """
     Configure Seq logging using a dictionary.
 
     Uses `logging.config.dictConfig()`.
+
+    Note that if you provide None to any of the default arguments, it just won't get changed (ie. it will stay the same).
 
     :param config: A dict containing the configuration.
     :type config: dict

--- a/seqlog/__init__.py
+++ b/seqlog/__init__.py
@@ -16,10 +16,11 @@ from seqlog.structured_logging import set_callback_on_failure as _set_callback_o
 
 __author__ = 'Adam Friedman'
 __email__ = 'tintoy@tintoy.io'
-__version__ = '0.3.31'
+__version__ = '0.4.0a1'
 
 
-def configure_from_file(file_name, override_root_logger=True, support_extra_properties=False, support_stack_info=False, ignore_seq_submission_errors=False):
+def configure_from_file(file_name, override_root_logger=True, support_extra_properties=False, support_stack_info=False, ignore_seq_submission_errors=False,
+                        use_clef=False):
     """
     Configure Seq logging using YAML-format configuration file.
 
@@ -35,19 +36,24 @@ def configure_from_file(file_name, override_root_logger=True, support_extra_prop
     :type support_stack_info: bool
     :param ignore_seq_submission_errors: Ignore errors encountered while sending log records to Seq?
     :type ignore_seq_submission_errors: bool
+    :param use_clef: use the newer submission format CLEF
+    :type use_clef: bool
     """
 
     configure_feature(FeatureFlag.EXTRA_PROPERTIES, support_extra_properties)
     configure_feature(FeatureFlag.STACK_INFO, support_stack_info)
     configure_feature(FeatureFlag.IGNORE_SEQ_SUBMISSION_ERRORS, ignore_seq_submission_errors)
+    configure_feature(FeatureFlag.USE_CLEF, use_clef)
 
     with open(file_name) as config_file:
         config = yaml.load(config_file, Loader=yaml.SafeLoader)
 
-    configure_from_dict(config, override_root_logger)
+    configure_from_dict(config, override_root_logger, True, support_extra_properties, support_stack_info,
+                        ignore_seq_submission_errors, use_clef)
 
 
-def configure_from_dict(config, override_root_logger=True, use_structured_logger=True, support_extra_properties=False, support_stack_info=False, ignore_seq_submission_errors=False):
+def configure_from_dict(config, override_root_logger=True, use_structured_logger=True, support_extra_properties=False, support_stack_info=False, ignore_seq_submission_errors=False,
+                        use_clef=False):
     """
     Configure Seq logging using a dictionary.
 
@@ -65,11 +71,14 @@ def configure_from_dict(config, override_root_logger=True, use_structured_logger
     :type support_stack_info: bool
     :param ignore_seq_submission_errors: Ignore errors encountered while sending log records to Seq?
     :type ignore_seq_submission_errors: bool
+    :param use_clef: use the newer submission format CLEF
+    :type use_clef: bool
     """
 
     configure_feature(FeatureFlag.EXTRA_PROPERTIES, support_extra_properties)
     configure_feature(FeatureFlag.STACK_INFO, support_stack_info)
     configure_feature(FeatureFlag.IGNORE_SEQ_SUBMISSION_ERRORS, ignore_seq_submission_errors)
+    configure_feature(FeatureFlag.USE_CLEF, use_clef)
 
     if override_root_logger:
         _override_root_logger()
@@ -87,6 +96,7 @@ def log_to_seq(server_url, api_key=None, level=logging.WARNING,
                json_encoder_class=None, support_extra_properties=False,
                support_stack_info=False,
                ignore_seq_submission_errors=False,
+               use_clef=False,
                **kwargs):
     """
     Configure the logging system to send log entries to Seq.
@@ -109,6 +119,8 @@ def log_to_seq(server_url, api_key=None, level=logging.WARNING,
     :type support_stack_info: bool
     :param ignore_seq_submission_errors: Ignore errors encountered while sending log records to Seq?
     :type ignore_seq_submission_errors: bool
+    :param use_clef: use more modern format to send events to Seq
+    :type use_clef: bool
     :return: The `SeqLogHandler` that sends events to Seq. Can be used to forcibly flush records to Seq.
     :rtype: SeqLogHandler
     """
@@ -116,6 +128,7 @@ def log_to_seq(server_url, api_key=None, level=logging.WARNING,
     configure_feature(FeatureFlag.EXTRA_PROPERTIES, support_extra_properties)
     configure_feature(FeatureFlag.STACK_INFO, support_stack_info)
     configure_feature(FeatureFlag.IGNORE_SEQ_SUBMISSION_ERRORS, ignore_seq_submission_errors)
+    configure_feature(FeatureFlag.USE_CLEF, use_clef)
 
     logging.setLoggerClass(StructuredLogger)
 

--- a/seqlog/feature_flags.py
+++ b/seqlog/feature_flags.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import typing as tp
 from enum import Enum
 
 
@@ -60,14 +60,14 @@ def disable_feature(feature: FeatureFlag):
     configure_feature(feature, False)
 
 
-def configure_feature(feature: FeatureFlag, enable: bool):
+def configure_feature(feature: FeatureFlag, enable: tp.Optional[bool]):
     """
     Enable or disable a feature.
 
-    :param feature: A `FeatureFlag` value representing the feature to configure.
+    :param feature: A `FeatureFlag` value representing the feature to configure. If you pass None, it won't get changed.
     :type feature: FeatureFlag
     :param enable: `True`, to enable the feature; `False` to disable it.
-    :type enable: bool
     """
-
+    if enable is None:
+        return
     _features[feature] = enable

--- a/seqlog/feature_flags.py
+++ b/seqlog/feature_flags.py
@@ -8,31 +8,21 @@ class FeatureFlag(Enum):
     Well-known feature flags.
     """
 
-    def __new__(cls, value, doc=None):
-        self = object.__new__(cls)  # calling super().__new__(value) here would fail
-        self._value_ = value
+    EXTRA_PROPERTIES = 1  #: Support passing of additional properties to log via the `extra` argument?
 
-        if doc is not None:
-            self.__doc__ = doc
+    STACK_INFO = 2  #: Support attaching of stack-trace information (if available) to log records?
 
-        return self
+    IGNORE_SEQ_SUBMISSION_ERRORS = 3   #: Ignore errors encountered while sending log records to Seq?
 
-    EXTRA_PROPERTIES = 1,
-    "Support passing of additional properties to log via the `extra` argument?"
-
-    STACK_INFO = 2,
-    "Support attaching of stack-trace information (if available) to log records?"
-
-    IGNORE_SEQ_SUBMISSION_ERRORS = 3,
-    "Ignore errors encountered while sending log records to Seq?"
+    USE_CLEF = 4    #: Use more modern API to submit log entries
 
 
 _features = {
     FeatureFlag.EXTRA_PROPERTIES: False,
     FeatureFlag.STACK_INFO: False,
     FeatureFlag.IGNORE_SEQ_SUBMISSION_ERRORS: False,
+    FeatureFlag.USE_CLEF: False
 }
-"Configured feature flags"
 
 
 def is_feature_enabled(feature: FeatureFlag):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ test_requirements = [
 
 setup(
     name='seqlog',
-    version='0.4.0a1',
+    version='0.4.0',
     description="SeqLog enables logging from Python to Seq.",
     long_description=readme + '\n\n' + history,
     author="Adam Friedman",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ test_requirements = [
 
 setup(
     name='seqlog',
-    version='0.3.31',
+    version='0.4.0a1',
     description="SeqLog enables logging from Python to Seq.",
     long_description=readme + '\n\n' + history,
     author="Adam Friedman",


### PR DESCRIPTION
In Seq 3.3 there's apparently a new log submission format on the market that works (I've tested it). Also, I've fixed some bugs. Overall, the changes are:

* You can enable and disable all of the feature flags at runtime
* Added support for the [CLEF submission format](https://docs.datalust.co/docs/posting-raw-events).
* Fixed a bug wherein configure_from_file would not propagate feature flags
    *  this was super problematic when you tried to set feature flags through configure_from_file, as they would later get overwritten
* You can pass bare strings in the exc_info field (although this serves the same purpose as enabling STACK_INFO and using that variable)
* A bugfix wherein `configure_from_file` would not relay it's arguments to `configure_from_dict` in the correct order

And I think that they warrant bumping minor version.