### PR TITLE
Add automatic testing via Tox and GitHub Actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,28 @@
+name: tox
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+      - name: Run tox
+        run: python -m tox

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: seqlog
-  version: 0.3.31
+  version: 0.5.0
 
 requirements:
   host:
@@ -17,4 +17,3 @@ about:
   home: http://github.com/tintoy/seqlog
   license: MIT
   license_file: LICENSE
-


### PR DESCRIPTION
I mean Travis demands you pay them. I say fuck them, let's use GitHub Actions.

Travis can test your script on Python 3.6, that's fine, GitHub can't do that. But it can test it on more modern Pythons.