### PR TITLE
Add automatic tests for later Pythons

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,28 @@
+name: tox
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+      - name: Run tox
+        run: python -m tox

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 SeqLog
 ===============================
 
+.. image:: https://github.com/tintoy/seqlog/actions/workflows/tox.yml/badge.svg
+        :target: https://github.com/tintoy/seqlog
 
 .. image:: https://img.shields.io/pypi/v/seqlog.svg
         :target: https://pypi.python.org/pypi/seqlog

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: seqlog
-  version: 0.3.31
+  version: 0.5.0
 
 requirements:
   host:
@@ -17,4 +17,3 @@ about:
   home: http://github.com/tintoy/seqlog
   license: MIT
   license_file: LICENSE
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py38, flake8
+envlist = py36, py38, py39, py310, py311, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
I understand your use case requires Python 3.6, but mine requires 3.11.

Plus Travis sucks.

Plus you get a nice shiny badge.

Plus now I know why it explicitly doesn't work on Python 3.7 xD