### PR TITLE
Catch value errors

### DIFF
--- a/seqlog/structured_logging.py
+++ b/seqlog/structured_logging.py
@@ -158,7 +158,7 @@ class StructuredLogRecord(logging.LogRecord):
         elif self.log_props:
             try:
                 return self.msg.format(**self.log_props)
-            except (KeyError, IndexError):
+            except (KeyError, IndexError, ValueError):
                 # IndexError because sometimes the wrong log messages go like {existing_prop[0]}
                 return self.msg   # handle the situation where we have braces in the logging value
         else:


### PR DESCRIPTION
Which can occur if the logs have uneven brackets due to unescaped input.


```
  File   File "C:\Users\micha\Documents\LPWork\MVP\src\PyScripts\aicore\pipeline.py", line 248, in run_method
    logger.error(f"Exception in {req.ai.code()}: {e}")
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\logging\__init__.py", line 1548, in error
    self._log(ERROR, msg, args, **kwargs)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\micha\AppData\Roaming\Python\Python313\site-packages\seqlog\structured_logging.py", line 221, in _log
    super()._log(level, msg, args, exc_info, extra, stack_info, stacklevel=2)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\logging\__init__.py", line 1664, in _log
    self.handle(record)
    ~~~~~~~~~~~^^^^^^^^
  File "C:\Python313\Lib\logging\__init__.py", line 1680, in handle
    self.callHandlers(record)
    ~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Python313\Lib\logging\__init__.py", line 1736, in callHandlers
    hdlr.handle(record)
    ~~~~~~~~~~~^^^^^^^^
  File "C:\Python313\Lib\logging\__init__.py", line 1026, in handle
    self.emit(record)
    ~~~~~~~~~^^^^^^^^
  File "C:\Users\micha\AppData\Roaming\Python\Python313\site-packages\seqlog\structured_logging.py", line 318, in emit
    msg = self.format(record)
  File "C:\Python313\Lib\logging\__init__.py", line 998, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "C:\Python313\Lib\logging\__init__.py", line 711, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "C:\Users\micha\AppData\Roaming\Python\Python313\site-packages\seqlog\structured_logging.py", line 160, in getMessage
    return self.msg.format(**self.log_props)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
ValueError: Single '}' encountered in format string line 248, in run_method
```